### PR TITLE
Update AlertDialog method

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/ui/ConfigurationFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/ConfigurationFragment.kt
@@ -759,6 +759,7 @@ class ConfigurationFragment @JvmOverloads constructor(
 
                                     shareLayout.setOnClickListener {
                                         AlertDialog.Builder(requireContext())
+                                            .setCancelable(false)
                                             .setTitle(R.string.insecure)
                                             .setMessage(resources.openRawResource(validateResult.textRes)
                                                 .bufferedReader().use { it.readText() })
@@ -787,6 +788,7 @@ class ConfigurationFragment @JvmOverloads constructor(
 
                                     shareLayout.setOnClickListener {
                                         AlertDialog.Builder(requireContext())
+                                            .setCancelable(false)
                                             .setTitle(R.string.deprecated)
                                             .setMessage(resources.openRawResource(validateResult.textRes)
                                                 .bufferedReader().use { it.readText() })


### PR DESCRIPTION
Prevent AlertDialog from closing on outside touch, avoid sharing event can't be executed.