### PR TITLE
Fix routing rule order to make FakeDNS work

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -1136,7 +1136,7 @@ fun buildV2RayConfig(
             })
         }
 
-        routing.rules.add(RoutingObject.RuleObject().apply {
+        routing.rules.add(0, RoutingObject.RuleObject().apply {
             type = "field"
             inboundTag = listOf(TAG_DNS_IN)
             outboundTag = TAG_DNS_OUT


### PR DESCRIPTION
Fix #192. `"outboundTag": "dns-out"` should be before `"outboundTag": "proxy-global-x"`. May also fix some other udp dns issues.