### PR TITLE
Add fdroidRelease build type

### DIFF
--- a/buildSrc/src/main/kotlin/Helpers.kt
+++ b/buildSrc/src/main/kotlin/Helpers.kt
@@ -348,6 +348,7 @@ fun Project.setupPlugin(projectName: String) {
         flavorDimensions("vendor")
         productFlavors {
             create("oss")
+            create("fdroid")
             create("fdroidArm64") {
                 versionNameSuffix = "-arm64"
             }


### PR DESCRIPTION
Since we (fdroid) don't have much capacity to manually update apps, and I've observed that you are not updating SagerNet in fdroid manually actively, it's reasonable to enable full auto update by providing a universal APK