### PR TITLE
删除 name.txt

### DIFF
--- a/metadata/en-US/name.txt
+++ b/metadata/en-US/name.txt
@@ -1,1 +1,0 @@
-SagerNet


### PR DESCRIPTION
因为 fdroidserver 的一些问题，存储库中的应用名不会被元数据中的覆盖，导致所有插件都显示为 SagerNet。目前删除这个文件应该是最简单的办法。