### PR TITLE
Minimize configuration for fake SSR

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -754,13 +754,16 @@ fun buildV2RayConfig(
                                             }
                                         }
                                         if (bean is ShadowsocksRBean) {
-                                            plugin = "shadowsocksr"
-                                            pluginArgs = listOf(
-                                                "--obfs=${bean.obfs}",
-                                                "--obfs-param=${bean.obfsParam}",
-                                                "--protocol=${bean.protocol}",
-                                                "--protocol-param=${bean.protocolParam}"
-                                            )
+                                            // plain & origin SSR does not require ShadowsocksR plugin
+                                            if (bean.obfs != "plain" && bean.protocol != "origin") {
+                                                plugin = "shadowsocksr"
+                                                pluginArgs = listOf(
+                                                    "--obfs=${bean.obfs}",
+                                                    "--obfs-param=${bean.obfsParam}",
+                                                    "--protocol=${bean.protocol}",
+                                                    "--protocol-param=${bean.protocolParam}"
+                                                )
+                                            }
                                         } else if (bean is ShadowsocksBean && bean.plugin.isNotBlank()) {
                                             val pluginConfiguration = PluginConfiguration(bean.plugin)
                                             try {


### PR DESCRIPTION
使用plain和origin的SSR的表现和SS相同，我称这类SSR为`fake SSR`，因此这些SSR不需要启用`shadowsocksr` plugin，直接当作普通shadowsocks运行即可。这里会做出一个判断，如果检测到fake SSR则不使用`shadowsocksr` plugin。  
部分奇怪的小机场使用了这种fake SSR，总让我感觉到不舒服，所以创建了这个提交。