### PR TITLE
Update workflow dependencies: 'checkout', 'cache', 'setup-go', etc.

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.7.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
   libcore:
@@ -28,12 +28,12 @@ jobs:
       - setup
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status library/core > libcore_status
       - name: LibCore Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             app/libs/libcore.aar
@@ -44,7 +44,7 @@ jobs:
         run: |
           echo ::set-output name=go_version::$(curl -s https://raw.githubusercontent.com/actions/go-versions/main/versions-manifest.json | grep -oE '"version": "[0-9]{1}.[0-9]{1,}(.[0-9]{1,})?"' | head -1 | cut -d':' -f2 | sed 's/ //g; s/"//g')
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: ${{ steps.version.outputs.go_version }}
@@ -58,18 +58,18 @@ jobs:
       - setup
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/trojan-go/*' > trojan_go_status
       - name: Trojan-Go Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/trojan-go/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/trojan_go/*', 'trojan_go_status') }}
       - name: Install Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: 1.17.1
@@ -87,12 +87,12 @@ jobs:
         arch: [ armeabi-v7a, arm64-v8a, x86, x86_64 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/naive/*' > naive_status
       - name: Naive Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/naive/src/main/jniLibs/${{ matrix.arch }}
@@ -107,7 +107,7 @@ jobs:
         run: |
           openssl sha256 plugin/naive/src/main/jniLibs/${{ matrix.arch }}/libnaive.so > sha256sum.txt
           echo "SHA256SUM=$(cut -d' ' -f2 sha256sum.txt)" >>$GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "NAIVE-SHA256-${{ matrix.arch }} ${{ env.SHA256SUM }}"
           path: sha256sum.txt
@@ -118,18 +118,18 @@ jobs:
   #      - setup
   #    steps:
   #      - name: Checkout
-  #        uses: actions/checkout@v2
+  #        uses: actions/checkout@v3
   #      - name: Fetch Status
   #        run: git submodule status 'plugin/pingtunnel/*' > pt_status
   #      - name: PingTunnel Cache
   #        id: cache
-  #        uses: actions/cache@v2
+  #        uses: actions/cache@v3
   #        with:
   #          path: |
   #            plugin/pingtunnel/src/main/jniLibs
   #          key: ${{ hashFiles('.github/workflows/*', 'bin/lib/pingtunnel/*', 'pt_status') }}
   #      - name: Install Golang
-  #        uses: actions/setup-go@v2
+  #        uses: actions/setup-go@v3
   #        if: steps.cache.outputs.cache-hit != 'true'
   #        with:
   #          go-version: 1.16
@@ -143,18 +143,18 @@ jobs:
       - setup
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/relaybaton/*' > rb_status
       - name: RelayBaton Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/relaybaton/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/relaybaton/*', 'rb_status') }}
       - name: Install Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: 1.16
@@ -168,18 +168,18 @@ jobs:
       - setup
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/brook/*' > brook_status
       - name: Brook Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/brook/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/brook/*', 'brook_status') }}
       - name: Install Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: 1.18.0
@@ -193,18 +193,18 @@ jobs:
       - setup
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/hysteria/*' > hysteria_status
       - name: Hysteria Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/hysteria/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/hysteria/*', 'hysteria_status') }}
       - name: Install Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: 1.18.6
@@ -218,18 +218,18 @@ jobs:
       - setup
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/mieru/*' > mieru_status
       - name: Mieru Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/mieru/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/mieru/*', 'mieru_status') }}
       - name: Install Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: 1.19.1
@@ -243,12 +243,12 @@ jobs:
       - setup
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/tuic/*' > tuic_status
       - name: Tuic Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/tuic/src/main/jniLibs
@@ -272,18 +272,18 @@ jobs:
       - libcore
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: |
           git submodule status library/core > libcore_status
       - name: LibCore Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             app/libs/libcore.aar
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/core/*', 'libcore_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}

--- a/.github/workflows/debug_apk.yml
+++ b/.github/workflows/debug_apk.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status library/core > libcore_status
       - name: LibCore Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             app/libs/libcore.aar
@@ -24,12 +24,12 @@ jobs:
         run: |
           echo ::set-output name=go_version::$(curl -s https://raw.githubusercontent.com/actions/go-versions/main/versions-manifest.json | grep -oE '"version": "[0-9]{1}.[0-9]{1,}(.[0-9]{1,})?"' | head -1 | cut -d':' -f2 | sed 's/ //g; s/"//g')
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: ${{ steps.version.outputs.go_version }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: ~/.gradle
@@ -47,18 +47,18 @@ jobs:
       - libcore
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: |
           git submodule status library/core > libcore_status
       - name: LibCore Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             app/libs/libcore.aar
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/core/*', 'libcore_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
@@ -74,23 +74,23 @@ jobs:
           APK=$(find app/build/outputs/apk -name '*arm64-v8a*.apk')
           APK=$(dirname $APK)
           echo "APK=$APK" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: APKs
           path: ${{ env.APK }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM ${{ env.SHA256_ARM }}"
           path: ${{ env.SUM_ARM }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM64 ${{ env.SHA256_ARM64 }}"
           path: ${{ env.SUM_ARM64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X64 ${{ env.SHA256_X64 }}"
           path: ${{ env.SUM_X64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X86 ${{ env.SHA256_X86 }}"
           path: ${{ env.SUM_X86 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check access"
-        uses: "lannonbr/repo-permission-check-action@2.0.0"
+        uses: "lannonbr/repo-permission-check-action@2.0.2"
         with:
           permission: "write"
         env:
@@ -31,12 +31,12 @@ jobs:
     needs: check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status library/core > libcore_status
       - name: LibCore Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             app/libs/libcore.aar
@@ -47,12 +47,12 @@ jobs:
         run: |
           echo ::set-output name=go_version::$(curl -s https://raw.githubusercontent.com/actions/go-versions/main/versions-manifest.json | grep -oE '"version": "[0-9]{1}.[0-9]{1,}(.[0-9]{1,})?"' | head -1 | cut -d':' -f2 | sed 's/ //g; s/"//g')
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: ${{ steps.version.outputs.go_version }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: ~/.gradle
@@ -70,18 +70,18 @@ jobs:
       - libcore
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: |
           git submodule status library/core > libcore_status
       - name: LibCore Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             app/libs/libcore.aar
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/core/*', 'libcore_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
@@ -97,23 +97,23 @@ jobs:
           APK=$(find app/build/outputs/apk -name '*arm64-v8a*.apk')
           APK=$(dirname $APK)
           echo "APK=$APK" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: APKs
           path: ${{ env.APK }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM ${{ env.SHA256_ARM }}"
           path: ${{ env.SUM_ARM }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM64 ${{ env.SHA256_ARM64 }}"
           path: ${{ env.SUM_ARM64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X64 ${{ env.SHA256_X64 }}"
           path: ${{ env.SUM_X64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X86 ${{ env.SHA256_X86 }}"
           path: ${{ env.SUM_X86 }}
@@ -124,9 +124,9 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -146,7 +146,7 @@ jobs:
     needs: build
     steps:
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -177,18 +177,18 @@ jobs:
       - libcore
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: |
           git submodule status library/core > libcore_status
       - name: LibCore Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             app/libs/libcore.aar
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/core/*', 'libcore_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}

--- a/.github/workflows/release_brook.yml
+++ b/.github/workflows/release_brook.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check access"
-        uses: "lannonbr/repo-permission-check-action@2.0.0"
+        uses: "lannonbr/repo-permission-check-action@2.0.2"
         with:
           permission: "write"
         env:
@@ -30,23 +30,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/brook/*' > brook_status
       - name: Brook Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/brook/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/brook/*', 'brook_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
       - name: Install Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: 1.18.0
@@ -61,17 +61,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/brook/*' > brook_status
       - name: brook Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/brook/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/brook/*', 'brook_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
@@ -88,23 +88,23 @@ jobs:
           APK=$(find plugin/brook/build/outputs/apk -name '*arm64-v8a*.apk')
           APK=$(dirname $APK)
           echo "APK=$APK" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: APKs
           path: ${{ env.APK }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM ${{ env.SHA256_ARM }}"
           path: ${{ env.SUM_ARM }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM64 ${{ env.SHA256_ARM64 }}"
           path: ${{ env.SUM_ARM64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X64 ${{ env.SHA256_X64 }}"
           path: ${{ env.SUM_X64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X86 ${{ env.SHA256_X86 }}"
           path: ${{ env.SUM_X86 }}
@@ -115,9 +115,9 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -137,7 +137,7 @@ jobs:
     needs: build
     steps:
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -169,17 +169,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/brook/*' > brook_status
       - name: brook Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/brook/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/brook/*', 'brook_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}

--- a/.github/workflows/release_hysteria.yml
+++ b/.github/workflows/release_hysteria.yml
@@ -30,23 +30,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/hysteria/*' > hysteria_status
       - name: Hysteria Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/hysteria/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/hysteria/*', 'hysteria_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
       - name: Install Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: 1.18.6
@@ -61,17 +61,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/hysteria/*' > hysteria_status
       - name: Hysteria Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/hysteria/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/hysteria/*', 'hysteria_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
@@ -88,23 +88,23 @@ jobs:
           APK=$(find plugin/hysteria/build/outputs/apk -name '*arm64-v8a*.apk')
           APK=$(dirname $APK)
           echo "APK=$APK" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: APKs
           path: ${{ env.APK }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM ${{ env.SHA256_ARM }}"
           path: ${{ env.SUM_ARM }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM64 ${{ env.SHA256_ARM64 }}"
           path: ${{ env.SUM_ARM64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X64 ${{ env.SHA256_X64 }}"
           path: ${{ env.SUM_X64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X86 ${{ env.SHA256_X86 }}"
           path: ${{ env.SUM_X86 }}
@@ -115,9 +115,9 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -137,7 +137,7 @@ jobs:
     needs: build
     steps:
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -169,17 +169,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/hysteria/*' > hysteria_status
       - name: Hysteria Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/hysteria/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/hysteria/*', 'hysteria_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}

--- a/.github/workflows/release_mieru.yml
+++ b/.github/workflows/release_mieru.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check access"
-        uses: "lannonbr/repo-permission-check-action@2.0.0"
+        uses: "lannonbr/repo-permission-check-action@2.0.2"
         with:
           permission: "write"
         env:
@@ -30,23 +30,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/mieru/*' > mieru_status
       - name: Mieru Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/mieru/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/mieru/*', 'mieru_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
       - name: Install Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: 1.19.1
@@ -61,17 +61,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/mieru/*' > mieru_status
       - name: Mieru Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/mieru/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/mieru/*', 'mieru_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
@@ -88,23 +88,23 @@ jobs:
           APK=$(find plugin/mieru/build/outputs/apk -name '*arm64-v8a*.apk')
           APK=$(dirname $APK)
           echo "APK=$APK" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: APKs
           path: ${{ env.APK }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM ${{ env.SHA256_ARM }}"
           path: ${{ env.SUM_ARM }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM64 ${{ env.SHA256_ARM64 }}"
           path: ${{ env.SUM_ARM64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X64 ${{ env.SHA256_X64 }}"
           path: ${{ env.SUM_X64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X86 ${{ env.SHA256_X86 }}"
           path: ${{ env.SUM_X86 }}
@@ -115,9 +115,9 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -137,7 +137,7 @@ jobs:
     needs: build
     steps:
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -169,17 +169,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/mieru/*' > mieru_status
       - name: Hysteria Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/mieru/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/mieru/*', 'mieru_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}

--- a/.github/workflows/release_naive.yml
+++ b/.github/workflows/release_naive.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check access"
-        uses: "lannonbr/repo-permission-check-action@2.0.0"
+        uses: "lannonbr/repo-permission-check-action@2.0.2"
         with:
           permission: "write"
         env:
@@ -34,18 +34,18 @@ jobs:
         arch: [ armeabi-v7a, arm64-v8a, x86, x86_64 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/naive/*' > naive_status
       - name: Naive Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/naive/src/main/jniLibs/${{ matrix.arch }}
           key: naive-${{ matrix.arch }}-${{ hashFiles('bin/plugin/naive/*', 'naive_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: ~/.gradle
@@ -62,7 +62,7 @@ jobs:
         run: |
           openssl sha256 plugin/naive/src/main/jniLibs/${{ matrix.arch }}/libnaive.so > sha256sum.txt
           echo "SHA256SUM=$(cut -d' ' -f2 sha256sum.txt)" >>$GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "NAIVE-SHA256-${{ matrix.arch }} ${{ env.SHA256SUM }}"
           path: sha256sum.txt
@@ -74,35 +74,35 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/naive/*' > naive_status
       - name: Naive Cache (armeabi-v7a)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/naive/src/main/jniLibs/armeabi-v7a
           key: naive-armeabi-v7a-${{ hashFiles('bin/plugin/naive/*', 'naive_status') }}
       - name: Naive Cache (arm64-v8a)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/naive/src/main/jniLibs/arm64-v8a
           key: naive-arm64-v8a-${{ hashFiles('bin/plugin/naive/*', 'naive_status') }}
       - name: Naive Cache (x86)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/naive/src/main/jniLibs/x86
           key: naive-x86-${{ hashFiles('bin/plugin/naive/*', 'naive_status') }}
       - name: Naive Cache (x86_64)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/naive/src/main/jniLibs/x86_64
           key: naive-x86_64-${{ hashFiles('bin/plugin/naive/*', 'naive_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: native-${{ hashFiles('**/*.gradle.kts') }}
@@ -119,23 +119,23 @@ jobs:
           APK=$(find plugin/naive/build/outputs/apk -name '*arm64-v8a*.apk')
           APK=$(dirname $APK)
           echo "APK=$APK" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: APKs
           path: ${{ env.APK }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM ${{ env.SHA256_ARM }}"
           path: ${{ env.SUM_ARM }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM64 ${{ env.SHA256_ARM64 }}"
           path: ${{ env.SUM_ARM64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X64 ${{ env.SHA256_X64 }}"
           path: ${{ env.SUM_X64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X86 ${{ env.SHA256_X86 }}"
           path: ${{ env.SUM_X86 }}
@@ -146,9 +146,9 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -168,7 +168,7 @@ jobs:
     needs: build
     steps:
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -200,35 +200,35 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/naive/*' > naive_status
       - name: Naive Cache (armeabi-v7a)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/naive/src/main/jniLibs/armeabi-v7a
           key: naive-armeabi-v7a-${{ hashFiles('bin/plugin/naive/*', 'naive_status') }}
       - name: Naive Cache (arm64-v8a)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/naive/src/main/jniLibs/arm64-v8a
           key: naive-arm64-v8a-${{ hashFiles('bin/plugin/naive/*', 'naive_status') }}
       - name: Naive Cache (x86)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/naive/src/main/jniLibs/x86
           key: naive-x86-${{ hashFiles('bin/plugin/naive/*', 'naive_status') }}
       - name: Naive Cache (x86_64)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/naive/src/main/jniLibs/x86_64
           key: naive-x86_64-${{ hashFiles('bin/plugin/naive/*', 'naive_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: native-${{ hashFiles('**/*.gradle.kts') }}

--- a/.github/workflows/release_pingtunnel.yml
+++ b/.github/workflows/release_pingtunnel.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check access"
-        uses: "lannonbr/repo-permission-check-action@2.0.0"
+        uses: "lannonbr/repo-permission-check-action@2.0.2"
         with:
           permission: "write"
         env:
@@ -30,18 +30,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/pingtunnel/*' > pt_status
       - name: PingTunnel Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/pingtunnel/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/pingtunnel/*', 'pt_status') }}
       - name: Install Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: 1.16
@@ -56,17 +56,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/pingtunnel/*' > pt_status
       - name: PingTunnel Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/pingtunnel/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/pingtunnel/*', 'pt_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
@@ -83,23 +83,23 @@ jobs:
           APK=$(find plugin/pingtunnel/build/outputs/apk -name '*arm64-v8a*.apk')
           APK=$(dirname $APK)
           echo "APK=$APK" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: APKs
           path: ${{ env.APK }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM ${{ env.SHA256_ARM }}"
           path: ${{ env.SUM_ARM }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM64 ${{ env.SHA256_ARM64 }}"
           path: ${{ env.SUM_ARM64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X64 ${{ env.SHA256_X64 }}"
           path: ${{ env.SUM_X64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X86 ${{ env.SHA256_X86 }}"
           path: ${{ env.SUM_X86 }}
@@ -110,9 +110,9 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -132,7 +132,7 @@ jobs:
     needs: build
     steps:
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -164,17 +164,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/pingtunnel/*' > pt_status
       - name: PingTunnel Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/pingtunnel/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/pingtunnel/*', 'pt_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}

--- a/.github/workflows/release_relaybaton.yml
+++ b/.github/workflows/release_relaybaton.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check access"
-        uses: "lannonbr/repo-permission-check-action@2.0.0"
+        uses: "lannonbr/repo-permission-check-action@2.0.2"
         with:
           permission: "write"
         env:
@@ -30,18 +30,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/relaybaton/*' > rb_status
       - name: RelayBaton Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/relaybaton/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/relaybaton/*', 'rb_status') }}
       - name: Install Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: 1.16
@@ -56,17 +56,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/relaybaton/*' > rb_status
       - name: RelayBaton Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/relaybaton/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/relaybaton/*', 'rb_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
@@ -83,23 +83,23 @@ jobs:
           APK=$(find plugin/relaybaton/build/outputs/apk -name '*arm64-v8a*.apk')
           APK=$(dirname $APK)
           echo "APK=$APK" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: APKs
           path: ${{ env.APK }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM ${{ env.SHA256_ARM }}"
           path: ${{ env.SUM_ARM }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM64 ${{ env.SHA256_ARM64 }}"
           path: ${{ env.SUM_ARM64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X64 ${{ env.SHA256_X64 }}"
           path: ${{ env.SUM_X64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X86 ${{ env.SHA256_X86 }}"
           path: ${{ env.SUM_X86 }}
@@ -110,9 +110,9 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -132,7 +132,7 @@ jobs:
     needs: build
     steps:
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -164,17 +164,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/relaybaton/*' > rb_status
       - name: RelayBaton Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/relaybaton/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/relaybaton/*', 'rb_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}

--- a/.github/workflows/release_trojan_go.yml
+++ b/.github/workflows/release_trojan_go.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check access"
-        uses: "lannonbr/repo-permission-check-action@2.0.0"
+        uses: "lannonbr/repo-permission-check-action@2.0.2"
         with:
           permission: "write"
         env:
@@ -30,18 +30,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/trojan-go/*' > trojan_go_status
       - name: Trojan-Go Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/trojan-go/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/trojan_go/*', 'trojan_go_status') }}
       - name: Install Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: 1.17.1
@@ -56,17 +56,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/trojan-go/*' > trojan_go_status
       - name: Trojan-Go Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/trojan-go/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/trojan_go/*', 'trojan_go_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
@@ -83,23 +83,23 @@ jobs:
           APK=$(find plugin/trojan-go/build/outputs/apk -name '*arm64-v8a*.apk')
           APK=$(dirname $APK)
           echo "APK=$APK" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: APKs
           path: ${{ env.APK }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM ${{ env.SHA256_ARM }}"
           path: ${{ env.SUM_ARM }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM64 ${{ env.SHA256_ARM64 }}"
           path: ${{ env.SUM_ARM64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X64 ${{ env.SHA256_X64 }}"
           path: ${{ env.SUM_X64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X86 ${{ env.SHA256_X86 }}"
           path: ${{ env.SUM_X86 }}
@@ -110,9 +110,9 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -132,7 +132,7 @@ jobs:
     needs: build
     steps:
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -164,17 +164,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/trojan-go/*' > trojan_go_status
       - name: Trojan-Go Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/trojan-go/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/trojan_go/*', 'trojan_go_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}

--- a/.github/workflows/release_tuic.yml
+++ b/.github/workflows/release_tuic.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check access"
-        uses: "lannonbr/repo-permission-check-action@2.0.0"
+        uses: "lannonbr/repo-permission-check-action@2.0.2"
         with:
           permission: "write"
         env:
@@ -30,18 +30,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/tuic/*' > tuic_status
       - name: TUIC Cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/tuic/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/tuic/*', 'tuic_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
@@ -65,17 +65,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/tuic/*' > tuic_status
       - name: TUIC Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/tuic/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/tuic/*', 'tuic_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
@@ -92,23 +92,23 @@ jobs:
           APK=$(find plugin/tuic/build/outputs/apk -name '*arm64-v8a*.apk')
           APK=$(dirname $APK)
           echo "APK=$APK" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: APKs
           path: ${{ env.APK }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM ${{ env.SHA256_ARM }}"
           path: ${{ env.SUM_ARM }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-ARM64 ${{ env.SHA256_ARM64 }}"
           path: ${{ env.SUM_ARM64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X64 ${{ env.SHA256_X64 }}"
           path: ${{ env.SUM_X64 }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "SHA256-X86 ${{ env.SHA256_X86 }}"
           path: ${{ env.SUM_X86 }}
@@ -119,9 +119,9 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -141,7 +141,7 @@ jobs:
     needs: build
     steps:
       - name: Donwload Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: APKs
           path: artifacts
@@ -173,17 +173,17 @@ jobs:
       - check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Status
         run: git submodule status 'plugin/tuic/*' > tuic_status
       - name: Hysteria Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             plugin/tuic/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/tuic/*', 'tuic_status') }}
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}


### PR DESCRIPTION
Many dependencies currently used by the workflows are outdated, which generates a lot of warnings.

This PR tries to fix this by updating those dependencies to latest versions.
