### PR TITLE
Fix deprecated 'set-output' in workflow

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -254,10 +254,9 @@ jobs:
             plugin/tuic/src/main/jniLibs
           key: ${{ hashFiles('.github/workflows/*', 'bin/lib/tuic/*', 'tuic_status') }}
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+          rustup toolchain install stable
+          rustup override set stable
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Install rust android target
         run: ./run init action rust

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -42,7 +42,7 @@ jobs:
         id: version
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          echo ::set-output name=go_version::$(curl -s https://raw.githubusercontent.com/actions/go-versions/main/versions-manifest.json | grep -oE '"version": "[0-9]{1}.[0-9]{1,}(.[0-9]{1,})?"' | head -1 | cut -d':' -f2 | sed 's/ //g; s/"//g')
+          echo go_version=$(curl -s https://raw.githubusercontent.com/actions/go-versions/main/versions-manifest.json | grep -oE '"version": "[0-9]{1}.[0-9]{1,}(.[0-9]{1,})?"' | head -1 | cut -d':' -f2 | sed 's/ //g; s/"//g') >> $GITHUB_OUTPUT
       - name: Setup Go
         uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/debug_apk.yml
+++ b/.github/workflows/debug_apk.yml
@@ -22,7 +22,7 @@ jobs:
         id: version
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          echo ::set-output name=go_version::$(curl -s https://raw.githubusercontent.com/actions/go-versions/main/versions-manifest.json | grep -oE '"version": "[0-9]{1}.[0-9]{1,}(.[0-9]{1,})?"' | head -1 | cut -d':' -f2 | sed 's/ //g; s/"//g')
+          echo go_version=$(curl -s https://raw.githubusercontent.com/actions/go-versions/main/versions-manifest.json | grep -oE '"version": "[0-9]{1}.[0-9]{1,}(.[0-9]{1,})?"' | head -1 | cut -d':' -f2 | sed 's/ //g; s/"//g') >> $GITHUB_OUTPUT
       - name: Setup Go
         uses: actions/setup-go@v3
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/release_tuic.yml
+++ b/.github/workflows/release_tuic.yml
@@ -46,10 +46,9 @@ jobs:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle.kts') }}
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+          rustup toolchain install stable
+          rustup override set stable
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Install rust android target
         run: ./run init action rust


### PR DESCRIPTION
This PR tries to fix currently used `set-output` commands in the workflow.

It also replaces 'actions-rs/toolchain' with bare `rustup` command, since that action haven't been updated in 2 years.

IMHO, it's not necessary to use an action, since `rustup` is included in GitHub Action's default Ubuntu [images](https://github.com/actions/runner-images) and the commands are not complex.
