### PR TITLE
Fix the issue of WIFI router strategy not working on Android 12

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/SagerNet.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/SagerNet.kt
@@ -275,6 +275,10 @@ class SagerNet : Application(),
                         ssid = transportInfo.ssid
                     }
                 }
+                if (WifiManager.UNKNOWN_SSID == ssid) {
+                    // try again from old api
+                    ssid = wifi.connectionInfo?.ssid
+                }
             } else {
                 val wifiInfo = wifi.connectionInfo
                 ssid = wifiInfo?.ssid


### PR DESCRIPTION
I have a Xiaomi 13 Ultra running on MIUI 14 system based on Android 13. I have noticed that the router I have set up to switch based on WIFI name is not working. No matter how many times I switch between WIFI and cellular data, the proxy configuration is not switching based on the router. SagerNet is always bypassing the configured WIFI policy routing.

When I reviewed the SagerNet source code, I found the following code snippet that retrieves the SSID name of the WIFI after the network status update:
``` kotlin
 fun reloadNetwork(network: Network?) {
            val capabilities = connectivity.getNetworkCapabilities(network) ?: return
            val networkType = when {
                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> "wifi"
                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI_AWARE) -> "wifi"
                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH) -> "bluetooth"
                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> "ethernet"
                else -> "data"
            }
            Libcore.setNetworkType(networkType)
            var ssid: String? = null
            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) { // key code here
                when (val transportInfo = capabilities.transportInfo) {
                    is WifiInfo -> {
                        ssid = transportInfo.ssid
                    }
                }
            } else {
                val wifiInfo = wifi.connectionInfo
                ssid = wifiInfo?.ssid
            }
            Libcore.setWifiSSID(ssid?.trim { it == '"' } ?: "")
        }
```

The SSID name is obtained from different APIs based on the system platform. According to the documentation mentioned here: [developer.android.com](https://developer.android.com/reference/android/net/wifi/WifiManager#getConnectionInfo()), on Android 12 and above platforms, a new API is required to obtain the SSID. However, based on my testing, I found that on my Xiaomi 13 (Android 13) and the Android emulator in Android Studio (Android 12), the API is unable to retrieve the correct SSID name and always returns `<unknown ssid>`.

I believe the solution to the problem would be to attempt to retrieve the SSID name through the old API when the new API is unavailable. Therefore, I made the changes as suggested in the pull request. After making the changes, I tested on both devices and was able to retrieve the SSID name correctly. The WIFI routing policy also started working correctly.

This modification should not affect the compatibility in the future when the old API is deprecated because it is highly unlikely that both APIs will be unable to return the correct SSID name. Therefore, using the old API as a fallback when the new API is unavailable should be a safe approach for now.