### PR TITLE
[PluginContract] fix a spelling mistake: 'plguin' -> 'plugin'.

### DIFF
--- a/plugin/api/src/main/java/io/nekohasekai/sagernet/plugin/PluginContract.kt
+++ b/plugin/api/src/main/java/io/nekohasekai/sagernet/plugin/PluginContract.kt
@@ -24,7 +24,7 @@ object PluginContract {
     const val ACTION_NATIVE_PLUGIN = "io.nekohasekai.sagernet.plugin.ACTION_NATIVE_PLUGIN"
     const val EXTRA_ENTRY = "io.nekohasekai.sagernet.plugin.EXTRA_ENTRY"
     const val METADATA_KEY_ID = "io.nekohasekai.sagernet.plugin.id"
-    const val METADATA_KEY_EXECUTABLE_PATH = "io.nekohasekai.sagernet.plguin.executable_path"
+    const val METADATA_KEY_EXECUTABLE_PATH = "io.nekohasekai.sagernet.plugin.executable_path"
     const val METHOD_GET_EXECUTABLE = "sagernet:getExecutable"
 
     const val COLUMN_PATH = "path"


### PR DESCRIPTION
I'm honestly not so sure if this is a typo. I checked PluginManager.kt and the initNativeFaster() function always seems to fail. The code uses "plguin", but the plugin uses "plugin". This appears to be the case for all plugins at the moment.

On my device, after changing "plguin" to "plugin", the initNative() function always returns quickly.

